### PR TITLE
Add macOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ the TPU VM instance unless otherwise stated.
 
     ```
 
+    The installation automatically uses `tensorflow-macos` on macOS and
+    `tensorflow-cpu` on other platforms.
+
 
 5.  Create Google Cloud Storage (GCS) bucket to store the dataset and model
     checkpoints. To create a GCS bucket, see these

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,9 @@ setuptools.setup(
         'optax @ git+https://github.com/deepmind/optax#egg=optax',
         'orbax-checkpoint >= 0.5',
         'seqio @ git+https://github.com/google/seqio#egg=seqio',
-        'tensorflow-cpu',
+        # Use macOS specific TensorFlow build when running on Darwin.
+        'tensorflow-cpu; platform_system!="Darwin"',
+        'tensorflow-macos; platform_system=="Darwin"',
         'tensorstore >= 0.1.20',
     ],
     extras_require={


### PR DESCRIPTION
## Summary
- switch to `tensorflow-macos` on macOS
- document the macOS TensorFlow package in README

## Testing
- `pip install -e .[test]` *(fails: Could not connect to proxy)*
- `pytest --maxfail=1 -q` *(fails: ModuleNotFoundError: No module named 'absl')*

------
https://chatgpt.com/codex/tasks/task_e_683bff74e2cc8327be8aade7500e1f8e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated installation instructions to clarify that the appropriate TensorFlow package is selected automatically based on the operating system.

- **Chores**
  - Improved dependency management to ensure the correct TensorFlow package is installed for macOS and other platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->